### PR TITLE
ADV-20410 fix test params

### DIFF
--- a/adapters/ogury/ogurytest/exemplary/banner_asset_ad_unit.json
+++ b/adapters/ogury/ogurytest/exemplary/banner_asset_ad_unit.json
@@ -8,6 +8,7 @@
           "format": [{"w": 128, "h": 100}]
         },
         "ext": {
+          "gpid": "global position id",
           "bidder": {
             "assetKey": "OGY",
             "adUnitId": "123"
@@ -26,17 +27,14 @@
           "imp": [
             {
               "id":"test-imp-id",
+              "tagid": "test-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
               "ext": {
+                "gpid": "global position id",
                 "assetKey": "OGY",
-                "adUnitId": "123",
-                "bidder": {
-                  "assetKey": "OGY",
-                  "adUnitId": "123"
-                },
-                "prebid": null
+                "adUnitId": "123"
               }
             }
           ]

--- a/adapters/ogury/ogurytest/supplemental/banner_with_arbitary_bidder_param.json
+++ b/adapters/ogury/ogurytest/supplemental/banner_with_arbitary_bidder_param.json
@@ -8,8 +8,11 @@
           "format": [{"w": 128, "h": 100}]
         },
         "ext": {
+          "gpid": "global position id",
           "bidder": {
-            "publisherId": "pub123"
+            "assetKey": "OGY",
+            "adUnitId": "123",
+            "testcampaign": "test123"
           }
         }
       }
@@ -30,7 +33,10 @@
                 "format": [{"w": 128, "h": 100}]
               },
               "ext": {
-                "publisherId": "pub123"
+                "gpid": "global position id",
+                "assetKey": "OGY",
+                "adUnitId": "123",
+                "testcampaign": "test123"
               }
             }
           ]
@@ -81,4 +87,3 @@
     }
   ]
 }
-


### PR DESCRIPTION
When we receive request there are fields under `imp.ext.bidder`. These fields are bidder specific params send from pbjs. We want to hoist those to `imp.ext` and to keep the rest of `imp.ext` fields in tact.