### PR TITLE
ADV-20406 remove adunitcode mapping

### DIFF
--- a/adapters/ogury/ogurytest/exemplary/banner_asset_ad_unit.json
+++ b/adapters/ogury/ogurytest/exemplary/banner_asset_ad_unit.json
@@ -3,15 +3,12 @@
     "id": "test-request-id",
     "imp": [
       {
-        "id": "test-imp-id",
+        "id": "ad-unit-code-as-imp-id",
         "banner": {
           "format": [{"w": 128, "h": 100}]
         },
         "ext": {
           "gpid": "global position id",
-          "prebid": {
-            "adunitcode": "ad-unit-code"
-          },
           "bidder": {
             "assetKey": "OGY",
             "adUnitId": "123"
@@ -29,23 +26,20 @@
           "id": "test-request-id",
           "imp": [
             {
-              "id":"test-imp-id",
-              "tagid": "ad-unit-code",
+              "id":"ad-unit-code-as-imp-id",
+              "tagid": "ad-unit-code-as-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
               "ext": {
                 "gpid": "global position id",
                 "assetKey": "OGY",
-                "adUnitId": "123",
-                "prebid": {
-                  "adunitcode": "ad-unit-code"
-                }
+                "adUnitId": "123"
               }
             }
           ]
         },
-        "impIDs":["test-imp-id"]
+        "impIDs":["ad-unit-code-as-imp-id"]
       },
       "mockResponse": {
         "status": 200,
@@ -57,7 +51,7 @@
               "seat": "seat",
               "bid": [{
                 "id": "some-UUID",
-                "impid": "test-imp-id",
+                "impid": "ad-unit-code-as-imp-id",
                 "price": 0.500000,
                 "adm": "adm string",
                 "crid": "crid_10",
@@ -78,7 +72,7 @@
         {
           "bid": {
             "id": "some-UUID",
-            "impid": "test-imp-id",
+            "impid": "ad-unit-code-as-imp-id",
             "price": 0.5,
             "adm": "adm string",
             "crid": "crid_10",

--- a/adapters/ogury/ogurytest/exemplary/banner_multi_imp_with_params.json
+++ b/adapters/ogury/ogurytest/exemplary/banner_multi_imp_with_params.json
@@ -1,6 +1,6 @@
 {
   "mockBidRequest": {
-    "id": "test-request-id",
+    "id": "filter-imp-without-ogury-params",
     "site": {
       "publisher": {
         "id": "pub123"
@@ -14,9 +14,6 @@
         },
         "ext": {
           "gpid": "global position id",
-          "prebid": {
-            "adunitcode": "ad-unit-code"
-          },
           "bidder": {
             "assetKey": "OGY",
             "adUnitId": "123"
@@ -37,9 +34,6 @@
         },
         "ext": {
           "gpid": "global position id",
-          "prebid": {
-            "adunitcode": "ad-unit-code-2"
-          },
           "bidder": {
             "assetKey": "OGY3",
             "adUnitId": "1234"
@@ -54,7 +48,7 @@
       "expectedRequest": {
         "uri": "http://ogury.example.com",
         "body": {
-          "id": "test-request-id",
+          "id": "filter-imp-without-ogury-params",
           "site": {
             "publisher": {
               "id": "pub123"
@@ -63,32 +57,26 @@
           "imp": [
             {
               "id":"test-imp-id",
-              "tagid": "ad-unit-code",
+              "tagid": "test-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
               "ext": {
                 "gpid": "global position id",
                 "assetKey": "OGY",
-                "adUnitId": "123",
-                "prebid": {
-                  "adunitcode": "ad-unit-code"
-                }
+                "adUnitId": "123"
               }
             },
             {
               "id":"test-imp-id-3",
-              "tagid": "ad-unit-code-2",
+              "tagid": "test-imp-id-3",
               "banner": {
                 "format": [{"w": 1, "h": 1}]
               },
               "ext": {
                 "gpid": "global position id",
                 "assetKey": "OGY3",
-                "adUnitId": "1234",
-                "prebid": {
-                  "adunitcode": "ad-unit-code-2"
-                }
+                "adUnitId": "1234"
               }
             }
           ]

--- a/adapters/ogury/ogurytest/exemplary/banner_multi_imp_without_ogury_params.json
+++ b/adapters/ogury/ogurytest/exemplary/banner_multi_imp_without_ogury_params.json
@@ -1,6 +1,6 @@
 {
   "mockBidRequest": {
-    "id": "test-request-id",
+    "id": "every-imp-without-param-dont-filter-imps",
     "site": {
       "publisher": {
         "id": "pub123"
@@ -14,9 +14,6 @@
         },
         "ext": {
           "gpid": "global position id",
-          "prebid": {
-            "adunitcode": "ad-unit-code"
-          },
           "bidder": {}
         }
       },
@@ -35,7 +32,7 @@
       "expectedRequest": {
         "uri": "http://ogury.example.com",
         "body": {
-          "id": "test-request-id",
+          "id": "every-imp-without-param-dont-filter-imps",
           "site": {
             "publisher": {
               "id": "pub123"
@@ -44,15 +41,12 @@
           "imp": [
             {
               "id":"test-imp-id",
-              "tagid": "ad-unit-code",
+              "tagid": "test-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
               "ext": {
-                "gpid": "global position id",
-                "prebid": {
-                  "adunitcode": "ad-unit-code"
-                }
+                "gpid": "global position id"
               }
             },
             {

--- a/adapters/ogury/ogurytest/exemplary/banner_publisher.json
+++ b/adapters/ogury/ogurytest/exemplary/banner_publisher.json
@@ -12,11 +12,7 @@
         "banner": {
           "format": [{"w": 128, "h": 100}]
         },
-        "ext": {
-          "prebid": {
-            "adunitcode": "ad-unit-code"
-          }
-        }
+        "ext": {}
       }
     ]
   },
@@ -35,15 +31,11 @@
           "imp": [
             {
               "id":"test-imp-id",
-              "tagid": "ad-unit-code",
+              "tagid": "test-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
-              "ext": {
-                "prebid": {
-                  "adunitcode": "ad-unit-code"
-                }
-              }
+              "ext": {}
             }
           ]
         },

--- a/adapters/ogury/ogurytest/supplemental/banner_with_arbitary_bidder_param.json
+++ b/adapters/ogury/ogurytest/supplemental/banner_with_arbitary_bidder_param.json
@@ -1,6 +1,6 @@
 {
   "mockBidRequest": {
-    "id": "test-request-id",
+    "id": "every-param-in-imp.ext.bidder-is-hoisted-to-imp.ext",
     "imp": [
       {
         "id": "test-imp-id",
@@ -9,9 +9,6 @@
         },
         "ext": {
           "gpid": "global position id",
-          "prebid": {
-            "adunitcode": "ad-unit-code"
-          },
           "bidder": {
             "assetKey": "OGY",
             "adUnitId": "123",
@@ -27,11 +24,11 @@
       "expectedRequest": {
         "uri": "http://ogury.example.com",
         "body": {
-          "id": "test-request-id",
+          "id": "every-param-in-imp.ext.bidder-is-hoisted-to-imp.ext",
           "imp": [
             {
               "id":"test-imp-id",
-              "tagid": "ad-unit-code",
+              "tagid": "test-imp-id",
               "banner": {
                 "format": [{"w": 128, "h": 100}]
               },
@@ -39,10 +36,7 @@
                 "gpid": "global position id",
                 "assetKey": "OGY",
                 "adUnitId": "123",
-                "testcampaign": "test123",
-                "prebid": {
-                  "adunitcode": "ad-unit-code"
-                }
+                "testcampaign": "test123"
               }
             }
           ]


### PR DESCRIPTION
Prebid [confirmed](https://github.com/prebid/prebid-server/issues/4077#issuecomment-2532472550) that `imp.id` is always the same as adUnitCode for prebid.js so we can remove the mapping from `imp.ext.prebid.adunitcode` to `imp.tagid` mapping from our code and just use `imp.id`